### PR TITLE
Makefiles and updated omim and chebi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+include Makefile.conf
+
+TARGETS= \
+        chebi \
+        omim
+
+N3_FILES=$(foreach tgt, $(TARGETS), $(N3_DIR)/$(tgt).n3)
+
+%.n3:
+	cd $(notdir $*); make n3
+
+%.n3.gz:
+	cd $(notdir $*); make n3.gz
+
+n3: $(N3_FILES)
+n3.gz: $(foreach n3, $(N3_FILES), $(n3).gz)
+
+all: n3
+
+%_clean_n3:
+	cd $(notdir $*); make clean_n3
+
+%_clean_downloads:
+	cd $(notdir $*); make clean_downloads
+
+clean_n3: $(foreach tgt, $(TARGETS), $(tgt)_clean_n3)
+clean_downloads: $(foreach tgt, $(TARGETS), $(tgt)_clean_downloads)
+
+clean: clean_n3 clean_downloads
+
+.PHONY: clean
+

--- a/Makefile.conf
+++ b/Makefile.conf
@@ -1,0 +1,2 @@
+N3_PATH=/tmp
+DOWNLOAD_PATH=/tmp

--- a/chebi/Makefile
+++ b/chebi/Makefile
@@ -1,0 +1,26 @@
+include ../Makefile.conf
+
+DOWNLOAD_DIR=$(DOWNLOAD_PATH)/chebi
+N3_FILE=$(N3_PATH)/chebi.n3
+
+n3: $(N3_FILE)
+n3.gz: $(N3_FILE).gz
+all: n3
+
+$(DOWNLOAD_DIR):
+	mkdir -p $(DOWNLOAD_DIR)
+	./chebi-wget.sh $(DOWNLOAD_DIR)
+
+$(N3_FILE): $(DOWNLOAD_DIR)
+	php chebi-2n3.php $(DOWNLOAD_DIR) 1>$(N3_FILE) 2>$(N3_FILE).err
+
+$(N3_FILE).gz: $(DOWNLOAD_DIR)
+	php chebi-2n3.php $(DOWNLOAD_DIR) | gzip 1>$(N3_FILE).gz 2>$(N3_FILE).err
+
+clean_downloads:
+	rm -Rf $(DOWNLOAD_DIR)
+
+clean_n3:
+	rm -f $(N3_FILE) $(N3_FILE).gz $(N3_FILE).err
+
+clean: clean_n3 clean_downloads

--- a/chebi/chebi-2n3.php
+++ b/chebi/chebi-2n3.php
@@ -23,11 +23,12 @@
 
 require_once('php-sql-parser.php');
 
+$argc == 2 or exit("Usage: php {$argv[0]} <download_path>");
 
 #Set the paths to all the SQL files that will be parsed
-$compound_path = "/home/jose/tmp/chebi/compounds.sql";
-$chemical_path = "/home/jose/tmp/chebi/chemical_data.sql";
-$names_path = "/home/jose/tmp/chebi/names.sql";
+$compound_path = "{$argv[1]}/compounds.sql";
+$chemical_path = "{$argv[1]}/chemical_data.sql";
+$names_path = "{$argv[1]}/names.sql";
 
 
 
@@ -39,10 +40,13 @@ $parser = new PHPSQLParser();
 /** Funciton Calls **/
 /********************/
 
+ob_start(NULL, 1024*1024); // enable buffering for faster IO
+
 parse_name_sql_file($names_path);
 parse_chemical_data_sql_file($chemical_path);
 parse_compound_sql_file($compound_path);
 
+ob_end_flush();
 
 /***************/
 /** Functions **/

--- a/chebi/chebi-wget.sh
+++ b/chebi/chebi-wget.sh
@@ -1,6 +1,9 @@
 # chebi-wget.sh
+set -e
 
-cd /bio2rdf/data/chebi
+DOWNLOAD_DIR=$1
+
+cd $DOWNLOAD_DIR
 
 rm -rf /bio2rdf/data/chebi/*
 

--- a/omim/Makefile
+++ b/omim/Makefile
@@ -1,0 +1,26 @@
+include ../Makefile.conf
+
+DOWNLOAD_DIR=$(DOWNLOAD_PATH)/omim
+N3_FILE=$(N3_PATH)/omim.n3
+
+n3: $(N3_FILE)
+n3.gz: $(N3_FILE).gz
+all: n3
+
+$(DOWNLOAD_DIR):
+	mkdir -p $(DOWNLOAD_DIR)
+	./omim-wget.sh $(DOWNLOAD_DIR)
+
+$(N3_FILE): $(DOWNLOAD_DIR)
+	perl omim-genemap2n3.pl $(DOWNLOAD_DIR)/ftp.ncbi.nih.gov/repository/OMIM/ARCHIVE/genemap 1>$(N3_FILE) 2>$(N3_FILE).err
+
+$(N3_FILE).gz: $(DOWNLOAD_DIR)
+	perl omim-genemap2n3.pl $(DOWNLOAD_DIR)/ftp.ncbi.nih.gov/repository/OMIM/ARCHIVE/genemap | gzip 1>$(N3_FILE).gz 2>$(N3_FILE).err
+
+clean_downloads:
+	rm -Rf $(DOWNLOAD_DIR)
+
+clean_n3:
+	rm -f $(N3_FILE) $(N3_FILE).gz $(N3_FILE).err
+
+clean: clean_n3 clean_downloads

--- a/omim/omim-genemap2n3.pl
+++ b/omim/omim-genemap2n3.pl
@@ -61,7 +61,7 @@ $nombreMax = 10000000;
 
 our $vocabulary = "http://bio2rdf.org/omim_vocabulary";
 
-open(INPUT, "</media/2tbdisk/bio2rdf/data/omim/genemap/genemap") || die "File $fichier unavailable:$!\n";
+open(INPUT, "<", $ARGV[0]) || die "File $fichier unavailable:$!\n";
 	
 while ($line = <INPUT>) {
 	$line =~ s/\\//g;

--- a/omim/omim-wget.sh
+++ b/omim/omim-wget.sh
@@ -1,9 +1,10 @@
 # omim-wget.sh
 # ftp://ftp.ncbi.nih.gov/repository/OMIM/
+set -e
 
-cd /bio2rdf/data/omim
-rm -rf /bio2rdf/data/omim/*
+DOWNLOAD_DIR=$1
 
-wget ftp://ftp.ncbi.nih.gov/repository/OMIM/*  --output-file=omim-wget.log
+cd $DOWNLOAD_DIR
+rm -rf $DOWNLOAD_DIR/*
 
-gunzip omim.txt.Z
+wget ftp://ftp.ncbi.nih.gov/repository/OMIM/* --recursive --output-file=omim-wget.log


### PR DESCRIPTION
With these Makefiles you can call e.g. `make omim.n3` to download and create the n3 file for omim automatically.
Calling `make` will download and create the n3 files for all targets (which are currently only omim and chebi)

You can apply the paths in `Makefile.conf`
