### PR TITLE
issue with naming of file in zip archive and command line argument

### DIFF
--- a/ndc/ndc.php
+++ b/ndc/ndc.php
@@ -92,6 +92,12 @@ class NDCParser extends RDFFactory
 		// now go through each item in the zip file and process
 		foreach($files AS $file) {
 			echo "Processing $file ...";
+
+			// the file name in the zip archive is Product not product
+			if($file == "product"){
+				$file = ucfirst($file);
+			}
+
 			$fpin = $zin->getStream($file.".txt");
 			if(!$fpin) {
 				trigger_error("Unable to get pointer to $file in $zinfile");


### PR DESCRIPTION
There was an issue with the NDC parser looking for the file named "product.txt" in the zip downloaded zip archive. The real file is named "Product.txt". The fix was the upper case the command line input then search directory.
