### PR TITLE
Drugbank changes to have output compatible with sesame 

### DIFF
--- a/drugbank/drugbank.php
+++ b/drugbank/drugbank.php
@@ -1,3 +1,4 @@
+#! /usr/bin/php
 <?php
 /**
 Copyright (C) 2012 Michel Dumontier
@@ -656,8 +657,10 @@ class DrugBankParser extends RDFFactory
 		if(isset($x->{"external-links"})) {
 			foreach($x->{"external-links"} AS $objs) {
 				foreach($objs AS $obj) {
-					$this->AddRDF($this->QQuadO_URL($did,"rdfs:seeAlso",$obj->url));
-				}
+                    if(strpos($obj->url,'http') !== false){
+                         $this->AddRDF($this->QQuadO_URL($did,"rdfs:seeAlso",$obj->url));
+                    }
+                }
 			}
 		}
 		


### PR DESCRIPTION
The sesame parser was not accepting certain characters, in particular the """ produced by QuadText method. These were changed to use QQuadL and SafeLiteral methods to generate acceptable literals.

This includes a "fix" to malformed urls being produced: 

> 2013-02-20 09:59:16,982 ERROR org.sindice.core.analytics.cascading.function.AbstractRDFParserFuntion: Couldn't parse statement: [http://bio2rdf.org/drugbank:DB00483 http://www.w3.org/2000/01/rdf-schema#seeAlso < Gallamine_triethiodide >  .]
