### PR TITLE
rdf -> nt file suffix to reflect actual RDF output type

### DIFF
--- a/mgi/mgi.php
+++ b/mgi/mgi.php
@@ -92,7 +92,7 @@ class MGIParser extends RDFFactory
 			}
 			$this->SetReadFile($lfile,true);
 			
-			$ofile = $odir."mgi-".$item.'.rdf.gz';
+			$ofile = $odir."mgi-".$item.'.nt.gz';
 			$this->SetWriteFile($ofile,true);
 			$this->$item();
 			$this->GetWriteFile()->Close();


### PR DESCRIPTION
Minor change to MGI parser to label output with NT instead of RDF . Found virtuoso would mistakenly use the RDF/XML parser when loading files with ld_dir and ld_dir_all functions.
