### PR TITLE
Fixed the resulted files naming, Add time measuring code.

### DIFF
--- a/affymetrix/affymetrix.php
+++ b/affymetrix/affymetrix.php
@@ -101,17 +101,24 @@ class AffymetrixParser extends RDFFactory
 		}
 		if(!isset($myfiles)) exit;
 
+		// print_r($myfiles);
 		foreach($myfiles AS $rfile) {
 			// download
 			$base_file = substr($rfile,strrpos($rfile,"/")+1);
-			echo "processing $base_file".PHP_EOL;
+			$base_url = substr($rfile,0, strrpos($rfile,"/"));
+			echo "processing $base_file, from $base_url".PHP_EOL;
 			$csv_file = $base_file.".csv";
 			$zip_file = $csv_file.".zip";
 		
 			$lfile = $ldir.$zip_file;
-			if(!file_exists($lfile) || $this->GetParameterValue("download") == "true") {
-				echo "Use download manager at http://www.freedownloadmanager.org/scripts/downl.php?file_id=1".PHP_EOL;
-				continue;
+
+			if(!file_exists($lfile) || $this->GetParameterValue('download') == true) { 
+				$rfile = $url.$zip_file;
+				trigger_error("Downloading $zip_file from $rfile", E_USER_NOTICE);
+				if(Utils::Download($base_url,array($zip_file),$ldir) === FALSE) {
+					trigger_error("Unable to download $file. skipping", E_USER_WARNING);
+					continue;
+				}
 			}
 			
 			// open the zip file
@@ -120,15 +127,17 @@ class AffymetrixParser extends RDFFactory
 				trigger_error("Unable to open $lfile");
 				exit;
 			}
+
 			if(($fp = $zin->getStream($csv_file)) === FALSE) {
 				trigger_error("Unable to get $csv_file in ziparchive $lfile");
 				return FALSE;
 			}
 			$this->SetReadFile($lfile);
 			$this->GetReadFile()->SetFilePointer($fp);
-			
+
 			// set the write file
 			$outfile = $base_file.'.nt'; $gz=false;
+			if($this->GetParameterValue('graph_uri')) {$outfile = $base_file.'.nq';}
 			if($this->GetParameterValue('gzip')) {
 				$outfile .= '.gz';
 				$gz = true;
@@ -148,6 +157,7 @@ class AffymetrixParser extends RDFFactory
 			$this->GetNamespace(),
 			"https://github.com/bio2rdf/bio2rdf-scripts/blob/master/affymetrix/affymetrix.php", 
 			$bio2rdf_download_files,
+			"dsfsdfs",
 			"http://affymetrix.com/",
 			array("use-share-modify","no-commercial"),
 			null, // license
@@ -319,9 +329,18 @@ class AffymetrixParser extends RDFFactory
 	}
 }
 
+$start = microtime(true);
+
 set_error_handler('error_handler');
 $parser = new AffymetrixParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
+
 ?>
 
 

--- a/biomodels/biomodels.php
+++ b/biomodels/biomodels.php
@@ -111,6 +111,7 @@ class BiomodelsParser extends RDFFactory
 		
 		// set the write file
 		$outfile = 'biomodels.nt'; $gz=false;
+		if($this->GetParameterValue('graph_uri')) {$outfile = 'biomodels.nq';}
 		if($this->GetParameterValue('gzip')) {
 			$outfile .= '.gz';
 			$gz = true;
@@ -175,8 +176,15 @@ class BiomodelsParser extends RDFFactory
 	}	
 
 }
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new BiomodelsParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>

--- a/clinical-trials/clinicaltrials.php
+++ b/clinical-trials/clinicaltrials.php
@@ -190,6 +190,7 @@ class ClinicalTrialsParser extends RDFFactory{
 		$outfile.=basename($infile,".xml").".nt";
 		
 		$gz = false;
+		if($this->GetParameterValue('gzip')){$outfile.=basename($infile,".xml").".nq";}
 		if($this->GetParameterValue('gzip')) {$outfile .= '.gz';$gz = true;}
 		
 		$this->SetWriteFile($outfile,$gz);
@@ -751,8 +752,16 @@ class ClinicalTrialsParser extends RDFFactory{
 
 	}
 }
+$start = microtime(true);
 
 $parser = new ClinicalTrialsParser($argv);
 $parser->run();
+
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 
 ?>

--- a/ctd/ctd.php
+++ b/ctd/ctd.php
@@ -75,12 +75,9 @@ class CTDParser extends RDFFactory
 
 		foreach($files AS $file) {
 			$lfile = $ldir.$file.$gz_suffix;
-			$ofile = $file.".nt";
-			$gz = false;
-			if($this->GetParameterValue('gzip') == "true") {
-				$gz = true;
-				$ofile .= ".gz";
-			}
+			$ofile = $file.".nt"; $gz = false;
+			if($this->GetParameterValue('graph_uri')) {$ofile = $file.'.nq';}
+			if($this->GetParameterValue('gzip')) {$ofile .= '.gz';$gz = true;}
 			$bio2rdf_download_files[] = $this->GetBio2RDFDownloadURL($this->GetNamespace()).$ofile;
 			
 			if(!file_exists($lfile)) {
@@ -643,9 +640,17 @@ function CTD_chem_gene_ixn_types()
 
 } // end class
 
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new CTDParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
+
 
 ?>

--- a/drugbank/drugbank.php
+++ b/drugbank/drugbank.php
@@ -94,6 +94,7 @@ class DrugBankParser extends RDFFactory
 		
 		// set the write file, parse, write and close
 		$ofile = 'drugbank.nt'; $gz=false;
+		if($this->GetParameterValue('graph_uri')) {$ofile = 'drugbank.nq';}
 		if($this->GetParameterValue('gzip')) {$ofile .= '.gz';$gz = true;}
 		$this->SetWriteFile($odir.$ofile, $gz);
 		$this->Parse($ldir,$file);
@@ -731,8 +732,15 @@ class DrugBankParser extends RDFFactory
 
 } // end class
 
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $dbparser = new DrugBankParser($argv);
 $dbparser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>

--- a/gene/entrez_gene.php
+++ b/gene/entrez_gene.php
@@ -107,8 +107,8 @@ class EntrezGeneParser extends RDFFactory{
 				file_put_contents($lfile,file_get_contents($rfile));
 			}
 			
-			$writefile = $odir.$id.".nt";
-			$gz=false;
+			$writefile = $odir.$id.".nt"; $gz=false;
+			if($this->GetParameterValue('graph_uri')) {$writefile = $odir.$id.".nq";}
 			if($this->GetParameterValue('gzip')){
 				$writefile .= '.gz';
 				$gz = true;
@@ -247,7 +247,7 @@ class EntrezGeneParser extends RDFFactory{
 		$this->GetReadFile()->Read(200000);
 		while($aLine = $this->GetReadFile()->Read(200000)){
 				$splitLine = explode("\t",$aLine);
-				if(count($splitLine) == 16){
+				if(count($splitLine) == 13){
 					$taxid = trim($splitLine[0]);
 					$aGeneId = trim($splitLine[1]);
 					$status = trim($splitLine[2]);
@@ -261,29 +261,6 @@ class EntrezGeneParser extends RDFFactory{
 					$endPositionOnGenomicAccession = trim($splitLine[10]);
 					$orientation = trim($splitLine[11]);
 					$assembly = trim($splitLine[12]);
-					$mature_peptide_accession_version = trim($splitLine[13]);
-					$mature_peptide_gi = trim($splitLine[14]);
-					$symbol = trim($splitLine[15]);
-
-
-					if($mature_peptide_accession_version != "-"){
-						$this->AddRDF($this->QQuad("geneid:".$aGeneId, 
-								"geneid_vocabulary:has_mature_peptide_gi",
-								"refseq:".$mature_peptide_accession_version));
-					}
-					//symbol
-					if($symbol != "-"){
-						$this->AddRDF($this->QQuadL("geneid:".$aGeneId, 
-								"geneid_vocabulary:has_gene_symbol",
-								$symbol));
-					}
-					//mature_peptide_gi
-					if($mature_peptide_gi != "-"){
-						$this->AddRDF($this->QQuad("geneid:".$aGeneId, 
-								"geneid_vocabulary:has_mature_peptide_gi",
-								"gi:".$mature_peptide_gi));
-					}
-
 					//taxid
 					$this->AddRDF($this->QQuad("geneid:".$aGeneId,
 							"geneid_vocabulary:has_taxid",
@@ -405,7 +382,7 @@ class EntrezGeneParser extends RDFFactory{
 		$this->GetReadFile()->Read(200000);
 		while($aLine = $this->GetReadFile()->Read(200000)){
 				$splitLine = explode("\t",$aLine);
-				if(count($splitLine) == 16){
+				if(count($splitLine) == 13){
 					$taxid =  trim($splitLine[0]);
 					$aGeneId = trim($splitLine[1]);
 					$status = trim($splitLine[2]);
@@ -419,26 +396,6 @@ class EntrezGeneParser extends RDFFactory{
 					$endPositionOnGenomicAccession = trim($splitLine[10]);
 					$orientation = trim($splitLine[11]);
 					$assembly = trim($splitLine[12]);
-					$mature_peptide_accession_version = trim($splitLine[13]);
-					$mature_peptide_gi = trim($splitLine[14]);
-					$symbol = trim($splitLine[15]);
-					if($mature_peptide_accession_version != "-"){
-						$this->AddRDF($this->QQuad("geneid:".$aGeneId, 
-								"geneid_vocabulary:has_mature_peptide_gi",
-								"refseq:".$mature_peptide_accession_version));
-					}
-					//symbol
-					if($symbol != "-"){
-						$this->AddRDF($this->QQuadL("geneid:".$aGeneId, 
-								"geneid_vocabulary:has_gene_symbol",
-								$symbol));
-					}
-					//mature_peptide_gi
-					if($mature_peptide_gi != "-"){
-						$this->AddRDF($this->QQuad("geneid:".$aGeneId, 
-								"geneid_vocabulary:has_mature_peptide_gi",
-								"gi:".$mature_peptide_gi));
-					}
 					//taxid
 					$this->AddRDF($this->QQuad("geneid:".$aGeneId,
 							"geneid_vocabulary:has_taxid",
@@ -659,8 +616,15 @@ class EntrezGeneParser extends RDFFactory{
 	}	
 }
 
+$start = microtime(true);
+
 set_error_handler('error_handler');
 $parser = new EntrezGeneParser($argv);
 $parser-> Run();
 
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>

--- a/goa/goa.php
+++ b/goa/goa.php
@@ -97,12 +97,9 @@ class GOAParser extends RDFFactory {
 				file_put_contents($lfile,file_get_contents($rfile));
 			}
 
-			$ofile = $odir."goa_".$file.'.nt'; 
-			$gz=false;	
-			if($this->GetParameterValue('gzip')) {
-				$ofile .= '.gz';
-				$gz = true;
-			}
+			$ofile = $odir."goa_".$file.'.nt'; $gz=false;	
+			if($this->GetParameterValue('graph_uri')) {$ofile = $odir."goa_".$file.'.nq';}
+			if($this->GetParameterValue('gzip')) {$ofile .= '.gz';$gz = true;}
 			
 			$this->SetReadFile($lfile, TRUE);
 			$this->SetWriteFile($ofile, $gz);
@@ -333,8 +330,16 @@ class GOAParser extends RDFFactory {
 
 }
 
+$start = microtime(true);
+
 set_error_handler('error_handler');
 $parser = new GOAParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 
 ?>

--- a/hgnc/hgnc.php
+++ b/hgnc/hgnc.php
@@ -89,7 +89,7 @@ class HGNCParser extends RDFFactory {
 
 		$ofile = $odir.$file.'.nt'; 
 		$gz=false;
-		
+		if($this->GetParameterValue('graph_uri')) {$ofile = $odir.$file.'.nq'; }
 		if($this->GetParameterValue('gzip')) {
 			$ofile .= '.gz';
 			$gz = true;
@@ -423,9 +423,16 @@ class HGNCParser extends RDFFactory {
 		}//while
 	}//process
 }//HGNCParser
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new HGNCParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 
 ?>

--- a/homologene/homologene.php
+++ b/homologene/homologene.php
@@ -91,9 +91,8 @@ class HomologeneParser extends RDFFactory{
 			file_put_contents($lfile,file_get_contents($rfile));
 		}
 
-		$ofile = $odir.$file.'.ttl'; 
-		$gz=false;
-		
+		$ofile = $odir.$file.'.nt'; $gz=false;
+		if($this->GetParameterValue('graph_uri')) {$ofile = $odir.$file.'.nq';}
 		if($this->GetParameterValue('gzip')) {
 			$ofile .= '.gz';
 			$gz = true;
@@ -162,6 +161,14 @@ class HomologeneParser extends RDFFactory{
 	}
 }
 
+$start = microtime(true);
+
 $parser = new HomologeneParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>

--- a/interpro/interpro.php
+++ b/interpro/interpro.php
@@ -83,6 +83,7 @@ class AffymetrixParser extends RDFFactory
 		
 		// set the write file
 		$outfile = 'interpro.nt'; $gz=false;
+		if($this->GetParameterValue('graph_uri')) {$outfile = 'interpro.nq';}
 		if($this->GetParameterValue('gzip')) {
 			$outfile .= '.gz';
 			$gz = true;
@@ -124,15 +125,16 @@ class AffymetrixParser extends RDFFactory
 		// now interate over the entries
 		foreach($xml->interpro AS $o) {
 			$this->WriteRDFBufferToWriteFile();
-			
+
 			$interpro_id = $o->attributes()->id;
-			echo "$interpro_id".PHP_EOL;
+			echo "Processing id... $interpro_id".PHP_EOL;
 			
 			$name = $o->name;
 			$short_name = $o->attributes()->short_name;
 			$type = $o->attributes()->type;
 			$s = "interpro:$interpro_id";
 			
+			echo "Adding... $s rdfs:label $name ($short_name) $type [$s]".PHP_EOL;
 			$this->AddRDF($this->QQuadL($s,"rdfs:label","$name ($short_name) $type [$s]"));
 			$this->AddRDF($this->QQuad($s,"rdf:type","interpro_vocabulary:$type"));
 			$this->AddRDF($this->QQuad($s,"void:inDataset",$this->GetDatasetURI()));
@@ -228,10 +230,17 @@ class AffymetrixParser extends RDFFactory
 	}
 
 }
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new AffymetrixParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>
 
 

--- a/ipi/ipi-wget.sh
+++ b/ipi/ipi-wget.sh
@@ -1,7 +1,9 @@
 # ipi-wget.sh
 
-cd /media/twotb/bio2rdf/data/ipi
-rm -rf /media/twotb/bio2rdf/data/ipi/*
+# Put your own locatio nwhere you wnat the data to be downloaded
+mkdir -p /Users/gabivulcu/Downloads/bio2-rdf-data/ipi/in
+cd /Users/gabivulcu/Downloads/bio2-rdf-data/ipi/in
+rm -rf /Users/gabivulcu/Downloads/bio2-rdf-data/ipi/in/*
 
-wget ftp://ftp.ebi.ac.uk/pub/databases/IPI/current/*.xrefs.gz --output-file=ipi.log
-gunzip *.gz
+wget ftp://ftp.ebi.ac.uk/pub/databases/IPI/last_release/current/*.xrefs.gz --output-file=ipi.log
+# gunzip *.gz

--- a/ipi/ipi2nt.php
+++ b/ipi/ipi2nt.php
@@ -23,9 +23,9 @@
 
 
 //Specify the path where the raw IPI files are located
-$input_path = "/tmp/ipi/ipi/";
+$input_path = "/Users/gabivulcu/Downloads/bio2-rdf-data/ipi/in";
 //Specify the path where the N-Triples files should be created
-$output_path = "/tmp/ipi/nt/";
+$output_path = "/Users/gabivulcu/Downloads/bio2-rdf-data/ipi/out";
 
 //TThe following are the files that this parser can handle
 $species_xrefs = array(
@@ -346,9 +346,11 @@ function parser_ipi_OSCODE_xref_gz_file($anInputPath, $anOSCODEFile, $outputPath
 		//no trailing slash
 		$outputPath .= "/";
 	}
+	echo "Processing $anInputPath, $anOSCODEFile, $outputPath ".PHP_EOL;
 	$out_fileName = substr($anOSCODEFile, 0, strrpos($anOSCODEFile, "."));
 	$ifh = gzopen($anInputPath.$anOSCODEFile, 'r') or die("Could not open ".$anInputPath.$anOSCODEFile."\n");
 	$outfh = fopen($outputPath.$out_fileName.".nt", 'w') or die ("Could not open file here!\n");
+
 
 	if($ifh){
 		while(!gzeof($ifh)){

--- a/iproclass/iproclass.php
+++ b/iproclass/iproclass.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
 Copyright (C) 2012 Alison Callahan
 
@@ -89,7 +89,7 @@ class IProClassParser extends RDFFactory{
 
 		$ofile = $odir.'iproclass.nt'; 
 		$gz = false;
-		
+		if($this->GetParameterValue('graph_uri')){$ofile = $odir.'iproclass.nq'; }
 		if($this->GetParameterValue('gzip')) {
 			$ofile .= '.gz';
 			$gz = true;
@@ -301,9 +301,15 @@ class IProClassParser extends RDFFactory{
 		}//while
 	}
 }
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new IProClassParser($argv);
 $parser->Run();
 
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>

--- a/irefindex/irefindex.php
+++ b/irefindex/irefindex.php
@@ -41,11 +41,11 @@ class iREFINDEXParser extends RDFFactory
 		$this->AddParameter('files',true,'all|10090|10116|4932|559292|562|6239|7227|9606|other','all','all or comma-separated list of files to process');
 		$this->AddParameter('indir',false,null,'/data/download/irefindex/','directory to download into and parse from');
 		$this->AddParameter('outdir',false,null,'/data/rdf/irefindex/','directory to place rdfized files');
-		$this->AddParameter('version',false,null,'10182011','dated version of files to download');
+		$this->AddParameter('version',false,null,'03022013','dated version of files to download');
 		$this->AddParameter('graph_uri',false,null,null,'provide the graph uri to generate n-quads instead of n-triples');
 		$this->AddParameter('gzip',false,'true|false','true','gzip the output');
 		$this->AddParameter('download',false,'true|false','false','set true to download files');
-		$this->AddParameter('download_url',false,null,'ftp://ftp.no.embnet.org/irefindex/data/current/psimi_tab/MITAB2.6/');
+		$this->AddParameter('download_url',false,null,'ftp://ftp.no.embnet.org/irefindex/data/current/psi_mitab/MITAB2.6/');
 		if($this->SetParameters($argv) == FALSE) {
 			$this->PrintParameters($argv);
 			exit;
@@ -78,7 +78,8 @@ class iREFINDEXParser extends RDFFactory
 			
 			$ofile = "irefindex-".$file.".nt";
 			$gz = false;
-			if($this->GetParameterValue("gzip") == "true") {
+			if($this->GetParameterValue("graph_uri")) {$ofile = "irefindex-".$file.".nq";}
+			if($this->GetParameterValue("gzip")) {
 				$gz = true;
 				$ofile .= ".gz";
 			}
@@ -90,7 +91,7 @@ class iREFINDEXParser extends RDFFactory
 			}
 			
 			if($this->GetParameterValue('download') == true) {
-				if(FALSE === Utils::Download("ftp://ftp.no.embnet.org",array("/irefindex/data/current/psimi_tab/MITAB2.6/".$zip_file),$ldir)) {
+				if(FALSE === Utils::Download("ftp://ftp.no.embnet.org",array("/irefindex/data/current/psi_mitab/MITAB2.6/".$zip_file),$ldir)) {
 					trigger_error("Error in Download");
 					return FALSE;
 				}
@@ -351,9 +352,16 @@ class iREFINDEXParser extends RDFFactory
 	}
 	
 }
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new iREFINDEXParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 
 ?>

--- a/mesh/mesh_parser.php
+++ b/mesh/mesh_parser.php
@@ -33,9 +33,9 @@ SOFTWARE.
 require('../../php-lib/rdfapi.php');
 class MeshParser extends RDFFactory{
 	private static $packageMap = array(
-		"descriptor_records" => "d2012.bin",
-		"qualifier_records" => "q2012.bin",
-		"supplementary_records" => "c2012.bin"					
+		"descriptor_records" => "d2013.bin",
+		"qualifier_records" => "q2013.bin",
+		"supplementary_records" => "c2013.bin"					
 	);
 	private static $descriptor_data_elements = array(
 		"AN" =>	"annotation",
@@ -156,7 +156,6 @@ class MeshParser extends RDFFactory{
 				}
 			}	
 		}
-	  
 	  //now iterate over the files array
 		foreach ($files as $k => $aFile){	
 			//ensure that there is a slash between directory name and filename
@@ -170,12 +169,14 @@ class MeshParser extends RDFFactory{
 
 			//ensure that there is a slash between directory name and filename
 			if(substr($odir, -1) == "/"){
-				$gzoutfile = $odir.$k.".ttl";
+				$gzoutfilename = $odir.$k;
 			} else {
-				$gzoutfile = $odir."/".$k.".ttl";
+				$gzoutfilename = $odir."/".$k;
 			}
-			$gz=false;
+			$gzoutfile = $gzoutfilename.".nt";
 
+			$gz=false;
+			if($this->GetParameterValue('graph_uri')){$gzoutfile = $gzoutfilename.".nq";}
 			if($this->GetParameterValue('gzip')){
 				$gzoutfile .= '.gz';
 				$gz = true;
@@ -983,7 +984,14 @@ class MeshParser extends RDFFactory{
 		return self::$descriptor_data_elements;
 	}
 }
+$start = microtime(true);
 
 $p = new MeshParser($argv);
 $p->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>

--- a/mgi/mgi.php
+++ b/mgi/mgi.php
@@ -93,8 +93,11 @@ class MGIParser extends RDFFactory
 			$this->SetReadFile($lfile,true);
 			
 			echo "Processing $item...";
-			$ofile = $odir."mgi-".$item.'.nt.gz';
-			$this->SetWriteFile($ofile,true);
+			$ofile = $odir."mgi-".$item.'.nt'; $gz=false;
+			if($this->GetParameterValue('graph_uri')) {$ofile = $odir."mgi-".$item.'.nq';;}
+			if($this->GetParameterValue('gzip')) {$ofile .= '.gz';$gz = true;}
+			
+			$this->SetWriteFile($ofile, $gz);
 			
 			$this->$item();
 			
@@ -238,9 +241,17 @@ class MGIParser extends RDFFactory
 	
 	}
 }
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new MGIParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
+
 ?>	
 		

--- a/ndc/ndc.php
+++ b/ndc/ndc.php
@@ -106,6 +106,7 @@ class NDCParser extends RDFFactory
 			
 			// set the write file
 			$outfile = $file.'.nt'; $gz=false;
+			if($this->GetParameterValue('graph_uri')) {$outfile = $file.'.nq';}
 			if($this->GetParameterValue('gzip')) {
 				$outfile .= '.gz';
 				$gz = true;

--- a/omim/omim.php
+++ b/omim/omim.php
@@ -95,6 +95,7 @@ class OMIMParser extends RDFFactory
 		
 		// set the write file
 		$outfile = 'omim.nt'; $gz=false;
+		if($this->GetParameterValue('graph_uri')) {$outfile = 'omim.nq';}
 		if($this->GetParameterValue('gzip')) {
 			$outfile .= '.gz';
 			$gz = true;

--- a/pathwaycommons/pathwaycommons.php
+++ b/pathwaycommons/pathwaycommons.php
@@ -96,8 +96,9 @@ class PathwaycommonsParser extends RDFFactory
 			fclose($fpin);
 
 			// set the output file
-			$outfile = $this->GetParameterValue('outdir').$source.'ttl';
+			$outfile = $this->GetParameterValue('outdir').$source.'nt';
 			$gz = false;
+			if($this->GetParameterValue('graph_uri')) {$outfile = $this->GetParameterValue('outdir').$source.'nq';}
 			if($this->GetParameterValue('gzip') == 'true') {
 				$outfile .= '.gz';
 				$gz = true;
@@ -311,9 +312,16 @@ LIMIT 1
 		}
 	}
 } 
-
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new PathwaycommonsParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
+
 ?>

--- a/pharmgkb/pharmgkb.php
+++ b/pharmgkb/pharmgkb.php
@@ -115,7 +115,8 @@ class PharmGKBParser extends RDFFactory
 			else $zipentries = array($file.".tsv");
 			
 			// set the write file, parse, write and close
-			$outfile = $odir.$file.'.ttl'; $gz=false;
+			$outfile = $odir.$file.'.nt'; $gz=false;
+			if($this->GetParameterValue('graph_uri')) {$outfile = $odir.$file.'.nq';}
 			if($this->GetParameterValue('gzip')) {$outfile .= '.gz';$gz = true;}
 			$this->SetWriteFile($outfile, $gz);
 			$bio2rdf_download_files[] = $this->GetBio2RDFDownloadURL($this->GetNamespace()).$outfile;
@@ -975,9 +976,15 @@ class PharmGKBParser extends RDFFactory
 		return TRUE;
 	}
 }
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new PharmGKBParser($argv);
 $parser->Run();
 
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>

--- a/pubmed/pubmed.php
+++ b/pubmed/pubmed.php
@@ -591,8 +591,14 @@ class PubmedParser extends RDFFactory
 	}
 }
 
+$start = microtime(true); 
+
 $parser = new PubmedParser($argv);
 $parser->Run();
 
-
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>

--- a/sabiork/sabiork.php
+++ b/sabiork/sabiork.php
@@ -129,9 +129,9 @@ class SABIORKParser extends RDFFactory
 				->SetDatasetURI($this->GetDatasetURI());
 			$rdf = $p->Parse();
 			
-			$ofile = "sabiork_$rid.owl";
-			$gz = false;
-			if($this->GetParameterValue("gzip") == "true") {
+			$ofile = "sabiork_$rid.nt";	$gz = false;
+			if($this->GetParameterValue("graph_uri")) {$ofile = "sabiork_$rid.nq";}
+			if($this->GetParameterValue("gzip")) {
 				$gz = true;
 				$ofile .= ".gz";
 			}
@@ -160,9 +160,16 @@ class SABIORKParser extends RDFFactory
 		$this->GetWriteFile()->Close();
 	} // run
 }
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new SABIORKParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>
 

--- a/sgd/sgd.php
+++ b/sgd/sgd.php
@@ -118,7 +118,7 @@ class SGDParser extends RDFFactory {
 
 			$ofile = $odir."sgd_".$file.'.nt'; 
 			$gz=false;
-			
+			if($this->GetParameterValue('graph_uri')) {$ofile = $odir."sgd_".$file.'.nq'; }
 			if($this->GetParameterValue('gzip')) {
 				$ofile .= '.gz';
 				$gz = true;
@@ -1062,9 +1062,16 @@ class SGDParser extends RDFFactory {
 	  	file_put_contents($target_filepath, file_get_contents('http://rest.bioontology.org/bioportal/virtual/download/'.$ontology_id.'?apikey='.$apikey));
 	}
 }//SGDParser
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new SGDParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 
 ?>

--- a/sider/sider.php
+++ b/sider/sider.php
@@ -90,9 +90,12 @@ class SIDERParser extends RDFFactory
 				echo "done!".PHP_EOL;
 			}
 			echo "processing $file";
-			$this->SetReadFile($lfile,true);			
-			$ofile = $odir."sider-".$file.'.nt.gz';
-			$this->SetWriteFile($ofile,true);
+			$this->SetReadFile($lfile,true);	
+			
+			$ofile = $odir."sider-".$file.'.nt'; $gz=false;
+			if($this->GetParameterValue('graph_uri')) {$ofile = $odir."sider-".$file.'.nq';}		
+			if($this->GetParameterValue('gzip')) {$ofile .= '.gz';$gz = true;}
+			$this->SetWriteFile($ofile,$gz);
 			$this->$file();
 			$this->GetWriteFile()->Close();
 			$this->GetReadFile()->Close();
@@ -293,8 +296,15 @@ PT for every side effect, but sometimes the PT is the same as the LLT.
 		
 	}
 }
+$start = microtime(true);
 
 set_error_handler('error_handler');
 $parser = new SIDERParser($argv);
 $parser->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>

--- a/taxonomy/ncbi_taxonomy_parser.php
+++ b/taxonomy/ncbi_taxonomy_parser.php
@@ -147,12 +147,14 @@ class NCBITaxonomyParser extends RDFFactory{
 						}
 						//ensure that there is a slash between directory name and filename
 						if(substr($odir, -1) == "/"){
-							$gzoutfile = $odir.$k.".nt";
+							$gzoutfilename = $odir.$k;
 						} else {
-							$gzoutfile = $odir."/".$k.".nt";
+							$gzoutfilename = $odir."/".$k;
 						}
+						$gzoutfile = $gzoutfilename.".nt";
 						//set the write file
 						$gz=false;
+						if($this->GetParameterValue('graph_uri')) {$gzoutfile = $gzoutfilename.".nq";}
 						if($this->GetParameterValue('gzip')) {
 							$gzoutfile .= '.gz';
 							$gz = true;
@@ -548,6 +550,15 @@ class NCBITaxonomyParser extends RDFFactory{
 	}//getpackagemap
 
 }//class
+$start = microtime(true);
+
 $p = new NCBITaxonomyParser($argv);
 $p->Run();
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
+
 ?>

--- a/unists/unists-wget.sh
+++ b/unists/unists-wget.sh
@@ -1,9 +1,13 @@
 # unists-wget.sh 
 
-cd /media/twotb/bio2rdf/data/unists
+mkdir -p /Users/gabivulcu/Downloads/bio2-rdf-data/unists/in
+mkdir -p /Users/gabivulcu/Downloads/bio2-rdf-data/unists/out
 
-rm -rf /media/twotb/bio2rdf/data/unists/*
+cd /Users/gabivulcu/Downloads/bio2-rdf-data/unists/in
+rm -rf /Users/gabivulcu/Downloads/bio2-rdf-data/unists/in/*
 
 #wget ftp://ftp.ncbi.nih.gov/repository/UniSTS/UniSTS_MapReports/Homo_sapiens/* --output-file=Homo_sapiens.log
 #wget ftp://ftp.ncbi.nih.gov/repository/UniSTS/UniSTS_MapReports/Mus_musculus/* --output-file=Mus_musculus.log
 wget -r ftp://ftp.ncbi.nih.gov/repository/UniSTS/UniSTS_MapReports/* --output-file=unists.log
+
+

--- a/unists/unists_parser.php
+++ b/unists/unists_parser.php
@@ -37,7 +37,7 @@ class UniSTSParser extends RDFFactory{
 	private static $packageMap = array(
 		"markers" =>  "UniSTS.sts",
 		"aliases" => "UniSTS.aliases",
-		"map_reports" => "ftp.ncbi.nlm.nih.gov/repository/UniSTS/UniSTS_MapReports/",
+		"map_reports" => "ftp.ncbi.nih.gov/repository/UniSTS/UniSTS_MapReports/",
 		//"pcr_reports" => "ftp.ncbi.nih.gov/repository/UniSTS/UniSTS_ePCR.Reports/"
 	);
 
@@ -89,16 +89,19 @@ class UniSTSParser extends RDFFactory{
 			} else {
 				$lfile = $ldir."/".$value;
 			}
-			if($key == "markers" || $key == "aliases"){		
+
+		if($key == "markers" || $key == "aliases"){		
 				//create a file pointer
 				$fp = gzopen($lfile, "r") or die("Could not open file ".$value."!\n");
 				//ensure that there is a slash between directory name and filename
 				if(substr($odir, -1) == "/"){
-					$gzoutfile = $odir.$key.".ttl";
+					$gzoutfilename = $odir.$key;
 				} else {
-					$gzoutfile = $odir."/".$key.".ttl";
+					$gzoutfilename = $odir."/".$key;
 				}
+				$gzoutfile = $gzoutfilename.".nt"; 
 				$gz=false;
+				if($this->GetParameterValue('graph_uri')){ $gzoutfile = $gzoutfilename.".nq";};
 				if($this->GetParameterValue('gzip')){
 					$gzoutfile .= '.gz';
 					$gz = true;
@@ -139,11 +142,13 @@ class UniSTSParser extends RDFFactory{
 					if($fn_no_ext == "README"){
 						//ensure that there is a slash between directory name and filename
 						if(substr($odir, -1) == "/"){
-							$gzoutfile = $odir.$pfn.$q."-".$fn_no_ext .".ttl";
+							$gzoutfilename = $odir.$pfn.$q."-".$fn_no_ext;
 						} else {
-							$gzoutfile = $odir."/".$pfn.$q."-".$fn_no_ext.".ttl";
+							$gzoutfilename = $odir."/".$pfn.$q."-".$fn_no_ext;
 						}
 						$gz=false;
+						$gzoutfile = $gzoutfilename.".nt";
+						if($this->GetParameterValue('graph_uri')){$gzoutfile = $gzoutfilename.".nq";}
 						if($this->GetParameterValue('gzip')){
 							$gzoutfile .= '.gz';
 							$gz = true;
@@ -169,11 +174,13 @@ class UniSTSParser extends RDFFactory{
 					elseif($fn_no_ext != "README" && $fn_no_ext != "README~" ){
 						//ensure that there is a slash between directory name and filename
 						if(substr($odir, -1) == "/"){
-							$gzoutfile = $odir.$pfn.$q."-".$fn_no_ext .".ttl";
+							$gzoutfilename = $odir.$pfn.$q."-".$fn_no_ext;
 						} else {
-							$gzoutfile = $odir."/".$pfn.$q."-".$fn_no_ext.".ttl";
+							$gzoutfilename = $odir."/".$pfn.$q."-".$fn_no_ext;
 						}
 						$gz=false;
+						$gzoutfile = $gzoutfilename.".nt";
+						if($this->GetParameterValue('graph_uri')){$gzoutfile = $gzoutfilename.".nq";}						
 						if($this->GetParameterValue('gzip')){
 							$gzoutfile .= '.gz';
 							$gz = true;
@@ -217,11 +224,13 @@ class UniSTSParser extends RDFFactory{
 						//echo $species_name_dir."\t".$fn_no_ext."\n";
 						//ensure that there is a slash between directory name and filename
 						if(substr($odir, -1) == "/"){
-							$gzoutfile = $odir.$species_name_dir.$q."-".$fn_no_ext .".ttl";
+							$gzoutfilename = $odir.$species_name_dir.$q."-".$fn_no_ext;
 						} else {
-							$gzoutfile = $odir."/".$species_name_dir.$q."-".$fn_no_ext.".ttl";
+							$gzoutfilename = $odir."/".$species_name_dir.$q."-".$fn_no_ext;
 						}
 						$gz=false;
+						$gzoutfile = $gzoutfilename.".nt";
+						if($this->GetParameterValue('graph_uri')){$gzoutfile = $gzoutfilename.".nq";}
 						if($this->GetParameterValue('gzip')){
 							$gzoutfile .= '.gz';
 							$gz = true;
@@ -729,9 +738,17 @@ class UniSTSParser extends RDFFactory{
 		return $rm;
 	}
 }//class
+$start = microtime(true);
 
 $p = new UniSTSParser($argv);
 //$a = $p->getFileR("/tmp",true);
 //$b = $p->filterByExtension($a, "txt");
 $p->Run();
+
+
+$end = microtime(true);
+$time_taken =  $end - $start;
+print "Started: ".date("l jS F \@ g:i:s a", $start)."\n";
+print "Finished: ".date("l jS F \@ g:i:s a", $end)."\n";
+print "Took: ".$time_taken." seconds\n"
 ?>


### PR DESCRIPTION
Hi,

I have been trying to run the bio2rdf scripts and I noticed that the naming of the resulted files for most of the scripts was not taking account of the presence or absence of the graph_uri property. Which means that most of the resulted files would be called *.nt even when the content was actually n-quads. Furthermore Some files were called *.ttl when the content was clearly n-triples or n-quads in case of presence of the graph_uri.

I also added time measuring for each of the scripts as they helped me monitoring how much time each script individually needs.

I hope this commit is helpful for you too.
Gabi
