### PR TITLE
Fixup download URL for CTD. Old URL results in 403 permanent redirect, w...

### DIFF
--- a/ctd/ctd.php
+++ b/ctd/ctd.php
@@ -43,7 +43,7 @@ class CTDParser extends RDFFactory
 		$this->AddParameter('graph_uri',false,null,null,'provide the graph uri to generate n-quads instead of n-triples');
 		$this->AddParameter('gzip',false,'true|false','true','gzip the output');
 		$this->AddParameter('download',false,'true|false','false','set true to download files');
-		$this->AddParameter('download_url',false,null,'http://ctd.mdibl.org/reports/');
+		$this->AddParameter('download_url',false,null,'http://ctdbase.org/reports/');
 		if($this->SetParameters($argv) == FALSE) {
 			$this->PrintParameters($argv);
 			exit;


### PR DESCRIPTION
Hey Michel

Here is my second attempt at a pull request, this one looks better. Rebasing on remote/origin/master helped. It looks like one of my two patches was already done by somebody else, so there is just one remaining: fixing the URL for CTD.

I'll send you more as I continue working on these

regards,
Martijn van Iersel
