### PR TITLE
003 hgnc parser update

### DIFF
--- a/hgnc/hgnc.php
+++ b/hgnc/hgnc.php
@@ -127,7 +127,17 @@ class HGNCParser extends RDFFactory {
 	}//Run
 
 	function process(){
-		$this->GetReadFile()->Read(4096);
+		$header = $this->GetReadFile()->Read(4096);
+		$expected = "HGNC ID	Approved Symbol	Approved Name	Status	Locus Type	Locus Group	Previous Symbols	Previous Names	Synonyms	Name Synonyms	Chromosome	Date Approved	Date Modified	Date Symbol Changed	Date Name Changed	Accession Numbers	Enzyme IDs	Entrez Gene ID	Ensembl Gene ID	Mouse Genome Database ID	Specialist Database Links	Specialist Database IDs	Pubmed IDs	RefSeq IDs	Gene Family Tag	Gene family description	Record Type	Primary IDs	Secondary IDs	CCDS IDs	VEGA IDs	Locus Specific Databases	Entrez Gene ID(supplied by NCBI)	OMIM ID(supplied by NCBI)	RefSeq(supplied by NCBI)	UniProt ID(supplied by UniProt)	Ensembl ID(supplied by Ensembl)	UCSC ID(supplied by UCSC)	Mouse Genome Database ID(supplied by MGI)	Rat Genome Database ID(supplied by RGD)\n";
+		if ($header != $expected)
+		{
+			echo PHP_EOL;
+			echo "FOUND :".$header.PHP_EOL;
+			echo "EXPCTD:".$expected.PHP_EOL;
+			trigger_error ("Header format is different than expected, please update the script");
+			exit;
+		}
+
 		while($l = $this->GetReadFile()->Read(4096)) {
 			$fields = explode("\t", $l);
 			$id = strtolower($fields[0]);


### PR DESCRIPTION
Hi,

These changes to hgnc.php might be useful.

I noticed that the current hgnc.tab has one fewer columns than the script was expecting, and as a consequence some variables were shifted around. The first commit should fix that. It also noticed quotes weren't escaped in one field, so I've added a call to SafeLiteral for that.

The second patch in this pull request adds a check that the contents of the header is what is expected, to get an early warning if the format changes again. It looks for an exact string match of the header, which may be more strict than necessary. Let me know if you prefer me to do it in another way.
## 

Martijn
